### PR TITLE
fixed v6 call where there was none

### DIFF
--- a/examples/geoloc/processors.py
+++ b/examples/geoloc/processors.py
@@ -136,7 +136,7 @@ def create_message(event_type, identifier, gi, src_ip, dst_ip):
     elif a_family == socket.AF_INET6:
         geoloc = geoloc_none( gi[a_family].record_by_addr_v6(src_ip) )
         if dst_ip:
-            geoloc2 = geoloc_none( gi[a_family].record_by_addr(dst_ip) )
+            geoloc2 = geoloc_none( gi[a_family].record_by_addr_v6(dst_ip) )
 
     message = {
         'type':   event_type, 


### PR DESCRIPTION
It was causing a bunch of errors in the geoloc.log about the wrong maxmind db because it was using the ipv4 version for ipv6 addresses. Swapped in the right function call.