### PR TITLE
not importing traceback here would crash geoloc.py

### DIFF
--- a/examples/geoloc/geoloc.py
+++ b/examples/geoloc/geoloc.py
@@ -81,6 +81,7 @@ def main():
             try:
                 m = p(identifier, payload, gi)
             except Exception, e:
+                import traceback
                 print "invalid message %s" % payload
                 traceback.print_exc(file=sys.stdout)
                 continue


### PR DESCRIPTION
For some reason w/o the import here geoloc.py would crash in this except statement. No idea why (yeah, horrible debugging) but it's been running over a week w/o a crash. It was crashing almost daily before.

TODO: Figure out the invalid message issue.