### PR TITLE
Update geoloc.py to use GeoLite2-City

### DIFF
--- a/examples/geoloc/geoloc.py
+++ b/examples/geoloc/geoloc.py
@@ -65,8 +65,8 @@ PROCESSORS = {
 def main():
     import socket
     gi = {}
-    gi[socket.AF_INET] = GeoIP.open("/opt/GeoLiteCity.dat",GeoIP.GEOIP_STANDARD)
-    gi[socket.AF_INET6] = GeoIP.open("/opt/GeoLiteCityv6.dat",GeoIP.GEOIP_STANDARD)
+    gi[socket.AF_INET] = GeoIP.open("/opt/GeoLite2-City.dat",GeoIP.GEOIP_STANDARD)
+    gi[socket.AF_INET6] = GeoIP.open("/opt/GeoLite2-City.dat",GeoIP.GEOIP_STANDARD)
 
     try:
         hpc = hpfeeds.new(HOST, PORT, IDENT, SECRET)


### PR DESCRIPTION
GeoLite is deprecated. GeoLite2 is the latest supported DB.